### PR TITLE
Mettre à jour le buildpack de metabase de 0.37.8 à 0.38.0 

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/Scalingo/buildpack-jvm-common
-https://github.com/metabase/metabase-buildpack#0.37.8
+https://github.com/metabase/metabase-buildpack#0.38.0


### PR DESCRIPTION
Mise à jour du buildpack dispo : https://github.com/metabase/metabase-buildpack/releases

**Pour tester (après le merge de la PR)** 
Aller sur l'appli `pix-metabase-production` sur scalingo et vérifier que ça se redéploie tout seul (y'a un hook qui est supposé re-déployer tout seul).
