### PR TITLE
Ajout d'une configuration de logger pour Metabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [Metabase](http://www.metabase.com/) is the easy, open source way for everyone in your company to ask questions and learn from data.
 
+# Using the log4j2 configuration
+
+To use the log4j2 configuration, you need to add `-Dlog4j.configurationFile=file:/app/log4j2.xml` to the JAVA_OPTS env variable .
+
+To get a clean parsing, you also need those variables to be set:
+
+- `MB_EMOJI_IN_LOGS`=`false`: Disables emoji in logs
+- `NO_COLOR`=`true`: Disables log coloration (https://no-color.org/)
+
 # Running Metabase on Heroku
 
 [Heroku](https://www.heroku.com/home) is a great place to evaluate Metabase and take it for a quick spin with just a click of a button and a couple minutes of waiting time. If you decide to keep your Metabase running long term we recommend some upgrades as noted in the documentation linked to below to avoid limitations of the Heroku free tier.

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -10,9 +10,9 @@
   <Loggers>
     <Logger name="metabase" level="INFO"/>
     <Logger name="metabase-enterprise" level="INFO"/>
-    <Logger name="metabase.plugins" level="DEBUG"/>
-    <Logger name="metabase.server.middleware" level="DEBUG"/>
-    <Logger name="metabase.query-processor.async" level="DEBUG"/>
+    <Logger name="metabase.plugins" level="INFO"/>
+    <Logger name="metabase.server.middleware" level="INFO"/>
+    <Logger name="metabase.query-processor.async" level="INFO"/>
     <Logger name="com.mchange" level="ERROR"/>
     <Logger name="liquibase" level="ERROR"/>
 

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -2,9 +2,8 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-      <JsonLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true">
+      <JsonLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeStacktrace="false">
         <KeyValuePair key="metabase_logger" value="json" />
-        <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </JsonLayout>
     </Console>
   </Appenders>

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-      <JsonLayout complete="false" compact="false">
+      <JsonLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true">
         <KeyValuePair key="metabase_logger" value="json" />
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </JsonLayout>

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
+      <JsonLayout complete="false" compact="false">
+        <KeyValuePair key="metabase_logger" value="json" />
+        <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
+      </JsonLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="metabase" level="INFO"/>
+    <Logger name="metabase-enterprise" level="INFO"/>
+    <Logger name="metabase.plugins" level="DEBUG"/>
+    <Logger name="metabase.server.middleware" level="DEBUG"/>
+    <Logger name="metabase.query-processor.async" level="DEBUG"/>
+    <Logger name="com.mchange" level="ERROR"/>
+    <Logger name="liquibase" level="ERROR"/>
+
+    <Root level="WARN">
+        <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## :unicorn: Problème
Le logger actuel de Metabase envoie les logs sur plusieurs lignes, et le format est difficilement parsable dans Datadog

## :robot: Solution
Modifier la configuration des logs de Metabase pour passer les logs en Json et supprimer tout ce qui n'est pas du texte

## :rainbow: Remarques
J'ai également désactiver les stack trace complètement, puisqu'elles ne nous sont aujourd'hui d'aucune utilité 

## :100: Pour tester
Déployer sur metabase-dev, et valider que les logs sont bien au format json, sans coloration ou emoji.
