### PR TITLE
Corriger le matching de tag metabase de renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "regexManagers": [
         {
             "fileMatch": ["^.buildpacks$"],
-            "matchStrings": ["https://github.com/1024pix/metabase-buildpack#(?<currentValue>\\S+)\\n?"],
+            "matchStrings": ["https://github.com/1024pix/metabase-buildpack#v(?<currentValue>\\S+)\\n?"],
             "depNameTemplate": "1024pix/metabase-buildpack",
             "datasourceTemplate": "github-tags",
             "extractVersionTemplate": "v(?<version>.*)"


### PR DESCRIPTION
## :unicorn: Problème
Renovate supprime le `v` de la version de metabase

## :robot: Proposition
Faire en sorte que renovate ne s'occupe que de la version de metabase et pas du tout du v

## :rainbow: Remarques
On suit le format de versioning metabase utilisant un v
