### PR TITLE
[TECH] Ajouter une tâche planifiée permettant de rendre la table sessions visible dans metabase

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,12 @@
+{
+  "jobs": [
+    {
+      "command": "7 * * * * bash ./scripts/make-table-visible.sh sessions",
+      "size": "S"
+    },
+    {
+      "command": "20 * * * * bash ./scripts/make-table-visible.sh sessions",
+      "size": "S"
+    }
+  ]
+}

--- a/scripts/make-table-visible.sh
+++ b/scripts/make-table-visible.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+table_name=${1}
+
+if [[ -z "$table_name" ]]; then
+  echo "Le nom de la table doit être fourni.";
+  exit 1
+fi
+
+if [[ -z "$DATABASE_URL" ]]; then
+  echo "La variable d'environnement DATABASE_URL doit être fournie."
+  exit 1
+fi
+
+psql "$DATABASE_URL" -c "UPDATE metabase_table SET visibility_type = null WHERE name = '$table_name';"


### PR DESCRIPTION
## :christmas_tree: Problème
Il existe une fonctionnalité dans metabase qui, lors d’une synchronisation des tables (toutes les heures sur les datawerhouse), va tenter de [cacher les tables issues de certains frameworks](https://github.com/metabase/metabase/blob/a223f819c72efd718e86e1267c3bed8ead447105/src/metabase/sync/sync_metadata/tables.clj#L26). C’est le cas de la table “sessions”. 

## :gift: Proposition
Ajouter une tâche planifiée qui s'exécutera après les synchronisations des bases `pix-datawarehouse-production` et `pix-datawarehouse-exproduction` afin de rendre la table `sessions` visible à nouveau.

## :socks: Remarques
Il existe deux crons, un toutes les heures à la 7ème minute pour  `pix-datawarehouse-production` et un toutes les heures à la 20ème minute pour ` pix-datawarehouse-ex-production` car je n'ai pas réussi à modifier l'horaire de déclenchement de la synchronisation pour  `pix-datawarehouse-ex-production`. 
